### PR TITLE
bug/issue#112 - 누락된 두 개의 메서드 추가

### DIFF
--- a/backend/users/domains/repositories/IUserRepository.ts
+++ b/backend/users/domains/repositories/IUserRepository.ts
@@ -14,7 +14,7 @@ export interface IUserRepository {
 
   // Read
   findById(id: string): Promise<User | null>;
-  findByUsername(username: string): Promise<User | null>; // username으로 조회 추가
+  findByNickname(nickname: string): Promise<User | null>; 
   findByEmail(email: string): Promise<User | null>;
   findAll(): Promise<User[] | undefined>;
   findByUserNicknameRoutineCompletion(

--- a/backend/users/infrastructures/repositories/PrUserRepository.ts
+++ b/backend/users/infrastructures/repositories/PrUserRepository.ts
@@ -17,7 +17,7 @@ export class PrUserRepository implements IUserRepository {
     },
   });
 
-  async create(user: User): Promise<User | undefined> {
+  async create(user: User): Promise<User> {
     try {
       const createdUser = await prisma.user.create({
         data: {
@@ -37,6 +37,7 @@ export class PrUserRepository implements IUserRepository {
       );
     } catch (e) {
       if (e instanceof Error) throw new Error(e.message);
+      throw new Error('사용자 생성에 실패했습니다.'); // 기본 에러 메시지
     }
   }
 
@@ -260,6 +261,30 @@ export class PrUserRepository implements IUserRepository {
     }
   }
 
+  async findByNickname(nickname: string): Promise<User | null> {
+    try {
+      const user = await prisma.user.findUnique({
+        where: { nickname },
+      });
+
+      if (!user) return null;
+
+      return new User(
+        user.username,
+        user.nickname,
+        user.profileImg,
+        null, // profileImgPath
+        user.id,
+        user.password,
+        user.email
+      );
+    } catch (e) {
+      if (e instanceof Error) throw new Error(e.message);
+      return null;
+    }
+  }
+
+
   async findById(id: string): Promise<User | null> {
     try {
       const user = await prisma.user.findUnique({
@@ -271,6 +296,31 @@ export class PrUserRepository implements IUserRepository {
       return new User(user.username, user.nickname, user.profileImg, user.id);
     } catch (e) {
       if (e instanceof Error) throw new Error(e.message);
+      return null;
+    }
+  }
+
+  async update(id: string, user: Partial<User>): Promise<User | null> {
+    try {
+      const updateData: Partial<User> = user;
+
+      const updatedUser = await prisma.user.update({
+        where: { id },
+        data: updateData,
+      });
+
+      return new User(
+        updatedUser.username,
+        updatedUser.nickname,
+        updatedUser.profileImg,
+        null, // profileImgPath
+        updatedUser.id,
+        updatedUser.password,
+        updatedUser.email
+      );
+    } catch (e) {
+      if (e instanceof Error) throw new Error(e.message);
+      return null;
     }
   }
 
@@ -351,6 +401,7 @@ export class PrUserRepository implements IUserRepository {
       return true;
     } catch (e) {
       if (e instanceof Error) throw new Error(e.message);
+      return false;
     }
   }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,9 +20,9 @@ model User {
   challenges     Challenge[]
   following      Follow[]            @relation("Following")
   followers      Follow[]            @relation("Followers")
+  reviews        Review[]
   completions    RoutineCompletion[]
   achievements   UserAchievement[]
-  reviews        Review[]
 
   @@map("users")
 }


### PR DESCRIPTION

## #️⃣ #112 

> close #112 

## 🚀 작업 내용 요약

> 작업 내용을 간략히 설명해주세요.
- findByNickname 메서드를 비롯해 누락되었다고 보고된 메서드 구현
- 추후 리팩토링이 필요해보입니다. Issue로 걸어드릴게요

## 📄 작업 내용 상세 (선택)

> 컴포넌트의 Props, API의 params, request body 등의 명세가 필요하다면 적어주세요.

### findByNickname
```typescript
async findByNickname(nickname: string): Promise<User | null> {
  try {
    const user = await prisma.user.findUnique({
      where: { nickname },
    });

    if (!user) return null;

    return new User(
      user.username,
      user.nickname,
      user.profileImg,
      null, // profileImgPath
      user.id,
      user.password,
      user.email
    );
  } catch (e) {
    if (e instanceof Error) throw new Error(e.message);
    return null;
  }
}
```

### update
```typescript
async update(id: string, user: Partial<User>): Promise<User | null> {
  try {
    const updateData: Partial<User> = user;

    const updatedUser = await prisma.user.update({
      where: { id },
      data: updateData,
    });

    return new User(
      updatedUser.username,
      updatedUser.nickname,
      updatedUser.profileImg,
      null, // profileImgPath
      updatedUser.id,
      updatedUser.password,
      updatedUser.email
    );
  } catch (e) {
    if (e instanceof Error) throw new Error(e.message);
    return null;
  }
}
```

## 📸 스크린샷 (FE 관련 이슈일 경우 선택)

## 💭 리뷰 요청사항 (선택)

> 리뷰하는 팀원이 특별히 검토했으면 하는 부분을 알려주세요.
> e.g. 이 함수 기능 구현은 되는데 로직을 더 깨끗하게 만들 수 있을까요?

## 🎸 기타 (선택)

> 이 외에 팀원들에게 알릴 내용이 있다면 적어주세요.
