### PR TITLE
Feat/issue#115 - Challenge Id를 활용한 특정 Challenge 조회 기능 추가

### DIFF
--- a/app/api/challenges/route.ts
+++ b/app/api/challenges/route.ts
@@ -20,13 +20,26 @@ const createAddChallengeUsecase = () => {
 };
 
 export const GET = async (
-  request: NextRequest,
-  { params }: { params: Promise<{ challengeId: number }> }
+  request: NextRequest
 ): Promise<NextResponse<ApiResponse<ChallengeDto | null>>> => {
-  const { challengeId } = await params;
+  const { searchParams } = new URL(request.url);
+  const challengeId = searchParams.get('id');
+
+  if (!challengeId) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'MISSING_PARAMETER',
+          message: '챌린지 ID가 필요합니다.',
+        },
+      },
+      { status: 400 }
+    );
+  }
 
   const usecase = createGetChallengeByIdUsecase();
-  const challenge = await usecase.execute(challengeId);
+  const challenge = await usecase.execute(Number(challengeId));
 
   if (!challenge) {
     return NextResponse.json(

--- a/app/api/challenges/route.ts
+++ b/app/api/challenges/route.ts
@@ -2,47 +2,59 @@
 // POST /api/challenges - 챌린지 등록
 import { NextRequest, NextResponse } from 'next/server';
 import { PrChallengeRepository } from '@/backend/challenges/infrastructures/repositories/PrChallengeRepository';
-import { GetAllChallengesUsecase } from '@/backend/challenges/applications/usecases/GetAllChallengesUsecase';
+import { GetChallengeByIdUsecase } from '@/backend/challenges/applications/usecases/GetChallengeByIdUsecase';
 import { ChallengeDtoMapper } from '@/backend/challenges/applications/dtos/ChallengeDto';
 import { AddChallengeUseCase } from '@/backend/challenges/applications/usecases/AddChallengeUsecase';
 import { AddChallengeRequestDto } from '@/backend/challenges/applications/dtos/AddChallengeDto';
 import { ChallengeDto } from '@/backend/challenges/applications/dtos/ChallengeDto';
+import { ApiResponse } from '@/backend/shared/types/ApiResponse';
 
 const repository = new PrChallengeRepository();
 
-const createGetAllChallengesUsecase = () => {
-  return new GetAllChallengesUsecase(repository);
+const createGetChallengeByIdUsecase = () => {
+  return new GetChallengeByIdUsecase(repository);
 };
 
 const createAddChallengeUsecase = () => {
   return new AddChallengeUseCase(repository);
 };
 
-// 실제로 서비스에서 사용되는 API는 아닙니다. -승민
-export const GET = async (): Promise<NextResponse<ChallengeDto[] | null>> => {
-  const usecase = createGetAllChallengesUsecase();
-  const challenges = await usecase.execute();
+export const GET = async (
+  request: NextRequest,
+  { params }: { params: Promise<{ challengeId: number }> }
+): Promise<NextResponse<ApiResponse<ChallengeDto | null>>> => {
+  const { challengeId } = await params;
 
-  return NextResponse.json(ChallengeDtoMapper.fromEntities(challenges));
+  const usecase = createGetChallengeByIdUsecase();
+  const challenge = await usecase.execute(challengeId);
+
+  if (!challenge) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: '챌린지를 찾을 수 없습니다.',
+        },
+      },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: ChallengeDtoMapper.fromEntity(challenge),
+    message: '챌린지 조회에 성공했습니다.',
+  });
 };
 
 // 챌린지 생성 API Post
-export const POST = async (requestBody: NextRequest): Promise<NextResponse> => {
+export const POST = async (requestBody: NextRequest): Promise<NextResponse<ApiResponse<ChallengeDto>>> => {
   const usecase = createAddChallengeUsecase();
-  console.log(requestBody);
   try {
-    // 요청 바디를 콘솔에 출력
-    console.log('=== POST /api/challenges 요청 시작 ===');
-    console.log('요청 URL:', requestBody.url);
-    console.log('요청 메서드:', requestBody.method);
-    console.log('요청 헤더:', Object.fromEntries(requestBody.headers.entries()));
-
     const requestChallenge: AddChallengeRequestDto = await requestBody.json();
-    console.log('요청 바디 (JSON):', JSON.stringify(requestChallenge, null, 2));
-    console.log('=== POST /api/challenges 요청 끝 ===');
 
     const challenge = await usecase.execute(requestChallenge);
-    console.log('생성된 챌린지:', challenge);
 
     return NextResponse.json(
       {

--- a/libs/api/challenges.api.ts
+++ b/libs/api/challenges.api.ts
@@ -54,7 +54,7 @@ export const createChallenge = async (
 // 3. 특정 챌린지 상세 조회
 export const getChallengeById = async (id: number): Promise<ApiResponse<ChallengeDto>> => {
   try {
-    const response = await axiosInstance.get<ApiResponse<ChallengeDto>>(`/api/challenges/${id}`);
+    const response = await axiosInstance.get<ApiResponse<ChallengeDto>>(`/api/challenges?id=${id}`);
     return response.data;
   } catch (error) {
     console.error('챌린지 상세 조회 실패:', error);


### PR DESCRIPTION
## #️⃣ #115 

> close #115 

## 🚀 작업 내용 요약

> Challenge Id를 활용한 특정 Challenge 조회 기능 추가

## 📄 작업 내용 상세 (선택)

> 컴포넌트의 Props, API의 params, request body 등의 명세가 필요하다면 적어주세요.

1. `api/challenges?id=`를 통한 조회가 가능하도록 route.ts 수정
2. `challenges.api.ts` 에서 API 엔드포인트 수정
3. Cursor에게 테스트 페이지 요청하여 테스트 완료 (테스트 페이지 삭제됨)

## 📸 스크린샷 (FE 관련 이슈일 경우 선택)

## 💭 리뷰 요청사항 (선택)

> 리뷰하는 팀원이 특별히 검토했으면 하는 부분을 알려주세요.
> e.g. 이 함수 기능 구현은 되는데 로직을 더 깨끗하게 만들 수 있을까요?

## 🎸 기타 (선택)

> 이 외에 팀원들에게 알릴 내용이 있다면 적어주세요.
